### PR TITLE
Make code CSS class names more flexible

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -110,7 +110,7 @@ rules.fencedCodeBlock = {
 
   replacement: function (content, node, options) {
     var className = node.firstChild.className || ''
-    var language = (className.match(/language-(\S+)/) || [null, ''])[1]
+    var language = (className.match(/(language-|lang-)?(\S+)/) || [null, ''])[2]
 
     return (
       '\n\n' + options.fence + language + '\n' +


### PR DESCRIPTION
[Highlight.js](https://www.npmjs.com/package/highlight.js) is one of the most popular syntax highlighters out there and it allows a code language to be specified via a prefix of `language-` or `lang-`. Additionally, you can also just put the language itself in the class without a prefix:
```html
<pre><code class="html">...</code></pre>
```

Popular documentation generators like TypeDoc use the `lang-` prefix, meaning that Turndown is unable to properly handled fenced code examples from TypeDoc generated docs.

This simple change allows every single one of those options to work and does **not** introduce any breaking changes.